### PR TITLE
dimensionality mode: honor n_splits for interaction case + fix flaky test

### DIFF
--- a/NEURALMI_REFERENCE.md
+++ b/NEURALMI_REFERENCE.md
@@ -390,24 +390,36 @@ Two sub-modes controlled by whether `y_data` is provided:
 | **Intrinsic** | None | MI between two halves of x channels |
 | **Interaction** | Provided | Direct MI between x and y |
 
-**Split methods** (`split_method` kwarg):
+**Split methods** (`split_method` kwarg — intrinsic mode only):
 - `'random'` — Random channel splits, repeated `n_splits` times (default)
 - `'spatial'` — Single split at channel midpoint
 - `'temporal'` — Correlates x with lag-shifted copy of itself (pass `lag=<int>`)
 
+**`n_splits` kwarg (default 5):**
+- *Intrinsic mode* (`split_method='random'`): number of distinct random channel-split assignments evaluated
+- *Interaction mode* (y_data provided): number of independent model fits from different random weight initialisations — gives a proper mean and std in the aggregated output
+
 **Key kwargs:** `n_workers=1`, `split_method='random'`, `n_splits=5`, `lag=<int>` (for temporal)
 
 **Returns:** `Results` with:
-- `result.dataframe` — columns: `embedding_dim`, `test_mi`, `participation_ratio`, `participation_ratio_singular`, `split_id`
+- `result.dataframe` — columns: `mi_mean`, `mi_std`, `participation_ratio_mean`, `participation_ratio_std` (aggregated over splits/runs); `result.details['raw_results']` contains per-run rows with `split_id`
 - `participation_ratio` — effective dimensionality from eigenvalue (covariance) spectrum: `(Σσᵢ²)² / Σσᵢ⁴` — stricter, weights large singular values more
 - `participation_ratio_singular` — PR from singular-value spectrum: `(Σσᵢ)² / Σσᵢ²` — less strict variant
 
 ```python
+# Intrinsic: MI between two random halves of x channels, 10 splits
 result = nmi.run(x, mode='dimensionality',
                  base_params={'n_epochs': 100},
                  n_splits=10, split_method='random',
                  n_workers=4)
-result.plot()    # MI vs split_id with participation ratio overlay
+result.plot()
+
+# Interaction: MI between x and y, 5 independent fits for mean/std
+result = nmi.run(x, y, mode='dimensionality',
+                 base_params={'n_epochs': 100},
+                 n_splits=5,
+                 n_workers=4)
+print(result.dataframe[['mi_mean', 'mi_std', 'participation_ratio_mean']])
 ```
 
 ---

--- a/docs/source/NEURALMI_REFERENCE.md
+++ b/docs/source/NEURALMI_REFERENCE.md
@@ -390,24 +390,36 @@ Two sub-modes controlled by whether `y_data` is provided:
 | **Intrinsic** | None | MI between two halves of x channels |
 | **Interaction** | Provided | Direct MI between x and y |
 
-**Split methods** (`split_method` kwarg):
+**Split methods** (`split_method` kwarg — intrinsic mode only):
 - `'random'` — Random channel splits, repeated `n_splits` times (default)
 - `'spatial'` — Single split at channel midpoint
 - `'temporal'` — Correlates x with lag-shifted copy of itself (pass `lag=<int>`)
 
+**`n_splits` kwarg (default 5):**
+- *Intrinsic mode* (`split_method='random'`): number of distinct random channel-split assignments evaluated
+- *Interaction mode* (y_data provided): number of independent model fits from different random weight initialisations — gives a proper mean and std in the aggregated output
+
 **Key kwargs:** `n_workers=1`, `split_method='random'`, `n_splits=5`, `lag=<int>` (for temporal)
 
 **Returns:** `Results` with:
-- `result.dataframe` — columns: `embedding_dim`, `test_mi`, `participation_ratio`, `participation_ratio_singular`, `split_id`
+- `result.dataframe` — columns: `mi_mean`, `mi_std`, `participation_ratio_mean`, `participation_ratio_std` (aggregated over splits/runs); `result.details['raw_results']` contains per-run rows with `split_id`
 - `participation_ratio` — effective dimensionality from eigenvalue (covariance) spectrum: `(Σσᵢ²)² / Σσᵢ⁴` — stricter, weights large singular values more
 - `participation_ratio_singular` — PR from singular-value spectrum: `(Σσᵢ)² / Σσᵢ²` — less strict variant
 
 ```python
+# Intrinsic: MI between two random halves of x channels, 10 splits
 result = nmi.run(x, mode='dimensionality',
                  base_params={'n_epochs': 100},
                  n_splits=10, split_method='random',
                  n_workers=4)
-result.plot()    # MI vs split_id with participation ratio overlay
+result.plot()
+
+# Interaction: MI between x and y, 5 independent fits for mean/std
+result = nmi.run(x, y, mode='dimensionality',
+                 base_params={'n_epochs': 100},
+                 n_splits=5,
+                 n_workers=4)
+print(result.dataframe[['mi_mean', 'mi_std', 'participation_ratio_mean']])
 ```
 
 ---

--- a/neural_mi/analysis/dimensionality.py
+++ b/neural_mi/analysis/dimensionality.py
@@ -52,7 +52,14 @@ def run_dimensionality_analysis(
           structure rather than cross-channel shared information.
         Defaults to 'random'.
     n_splits : int, optional
-        Number of random channel splits (only applies when split_method='random').
+        Number of independent runs.  For intrinsic dimensionality with
+        ``split_method='random'`` this controls how many distinct random
+        channel-split assignments are evaluated.  For interaction
+        dimensionality (``y_data`` provided) there is no channel split, so
+        ``n_splits`` instead controls how many independent model fits are
+        performed — each starting from a different random weight
+        initialisation — giving a proper mean and standard deviation in the
+        output.  Defaults to 5.
     spectral_output : {'default', 'all'}, optional
         'default' returns only participation_ratio; 'all' returns all spectral metrics.
     return_spectrum : bool, optional
@@ -92,13 +99,19 @@ def run_dimensionality_analysis(
 
     # 2. Interaction Dimensionality (X and Y both provided)
     if y_data is not None:
-        logger.info("y_data provided. Computing Interaction Dimensionality.")
-        sweep = ParameterSweep(x_data=x_data, y_data=y_data, base_params=analysis_params)
-        results = sweep.run(sweep_grid=sweep_grid or {}, n_workers=n_workers,
-                            is_proc_sweep=False)
-        df = pd.DataFrame(results)
-        df['split_id'] = 0
-        return df
+        logger.info(
+            f"y_data provided. Computing Interaction Dimensionality "
+            f"({n_splits} independent run{'s' if n_splits != 1 else ''})."
+        )
+        all_results = []
+        for i in range(n_splits):
+            if n_splits > 1:
+                logger.info(f"--- Interaction Run {i + 1}/{n_splits} ---")
+            run_rows = _run_single_split(
+                x_data, y_data, analysis_params, sweep_grid, n_workers, split_id=i
+            )
+            all_results.extend(run_rows)
+        return pd.DataFrame(all_results)
 
     # 3. Intrinsic Dimensionality (only X provided — channel split)
     logger.info(f"Computing Intrinsic Dimensionality using '{split_method}' splits.")

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -154,9 +154,16 @@ def test_critic_chunking_equivalency(critic_type, x_data, y_data):
     critic_chunked = critic_class(**kwargs, max_n_batches=3)
     scores_chunked, kl_chunked = critic_chunked(x_data, y_data)
 
-    # 3. Assert mathematical equivalence
-    assert torch.allclose(scores_full, scores_chunked, atol=1e-5), f"{critic_type} chunking altered the score matrix!"
-    assert torch.allclose(kl_full, kl_chunked, atol=1e-5), f"{critic_type} chunking altered the variational KL loss!"
+    # 3. Assert mathematical equivalence.
+    # Float32 chunk-reorder accumulation gives differences proportional to the value
+    # magnitude — up to ~0.1 for large bilinear scores (Separable, ~10^5) and ~1e-5
+    # for small near-zero scores (Hybrid decision head).  We therefore use both a
+    # relative tolerance (1e-4) and an absolute floor (1e-4) so both regimes are
+    # covered while still catching real discrepancies.
+    assert torch.allclose(scores_full, scores_chunked, rtol=1e-4, atol=1e-4), \
+        f"{critic_type} chunking altered the score matrix!"
+    assert torch.allclose(kl_full, kl_chunked, rtol=1e-4, atol=1e-4), \
+        f"{critic_type} chunking altered the variational KL loss!"
 
 # --- Gradient Tests for Critics ---
 


### PR DESCRIPTION
dimensionality.py:
- Interaction mode (y_data provided) now loops n_splits times over independent model fits from different random weight initialisations, exactly mirroring what intrinsic mode does across channel splits. Previously the single run still produced mi_mean/mi_std columns but mi_std was always 0 (meaningless with N=1).  The aggregation in run.py already handles multiple split_id rows correctly.
- Updated n_splits docstring to document its meaning for both modes.

NEURALMI_REFERENCE.md (both copies):
- §6.3: clarify n_splits semantics for intrinsic vs interaction mode, update Returns to show aggregated column names (mi_mean, mi_std, participation_ratio_mean), add interaction mode code example.

tests/test_models.py:
- Fix flaky test_critic_chunking_equivalency: replace atol=1e-5 with rtol=1e-4, atol=1e-4 to handle both large bilinear scores (~10^5) and near-zero decision-head scores (~0.035) under float32 chunk- reorder accumulation.