### PR TITLE
fix: ensure pool task tensors are always on CPU (MPS/CUDA crash)

### DIFF
--- a/neural_mi/analysis/dimensionality.py
+++ b/neural_mi/analysis/dimensionality.py
@@ -14,7 +14,7 @@ from tqdm.auto import tqdm
 
 from .sweep import ParameterSweep
 from neural_mi.logger import logger
-from neural_mi.utils import _configure_multiprocessing
+from neural_mi.utils import _configure_multiprocessing, _ensure_cpu
 
 
 # ---------------------------------------------------------------------------
@@ -183,8 +183,9 @@ def run_dimensionality_analysis(
             f"y_data provided. Computing Interaction Dimensionality "
             f"({n_splits} independent run{'s' if n_splits != 1 else ''})."
         )
+        x_cpu, y_cpu = _ensure_cpu(x_data), _ensure_cpu(y_data)
         split_tasks = [
-            (x_data, y_data, analysis_params, sweep_grid, i)
+            (x_cpu, y_cpu, analysis_params, sweep_grid, i)
             for i in range(n_splits)
         ]
         all_results = _dispatch_splits(split_tasks, n_workers, show_progress)
@@ -211,7 +212,7 @@ def run_dimensionality_analysis(
             f"Temporal split at lag={lag} samples: {x_a.shape[0]} aligned sample pairs."
         )
         # Only one temporal split — forward n_workers into the inner ParameterSweep
-        split_tasks = [(x_a, x_b, analysis_params, sweep_grid, 0)]
+        split_tasks = [(_ensure_cpu(x_a), _ensure_cpu(x_b), analysis_params, sweep_grid, 0)]
         all_results = _dispatch_splits(split_tasks, n_workers, show_progress)
 
     elif split_method in ('random', 'spatial'):
@@ -242,7 +243,7 @@ def run_dimensionality_analysis(
                 else:  # 3D (N, C, W)
                     x_a = x_data[:, :half, :]
                     x_b = x_data[:, half:, :]
-            split_tasks.append((x_a, x_b, analysis_params, sweep_grid, i))
+            split_tasks.append((_ensure_cpu(x_a), _ensure_cpu(x_b), analysis_params, sweep_grid, i))
 
         all_results = _dispatch_splits(split_tasks, n_workers, show_progress)
 

--- a/neural_mi/analysis/rigorous.py
+++ b/neural_mi/analysis/rigorous.py
@@ -24,7 +24,7 @@ from typing import Any, Dict, List, Optional
 from neural_mi.analysis.task import run_training_task
 from neural_mi.logger import logger
 from neural_mi.exceptions import InsufficientDataError, TrainingError
-from neural_mi.utils import _configure_multiprocessing
+from neural_mi.utils import _configure_multiprocessing, _ensure_cpu
 
 
 # ---------------------------------------------------------------------------
@@ -267,12 +267,8 @@ class AnalysisWorkflow:
                     )
 
                 for i_subset, subset_indices in enumerate(chunks):
-                    x_subset = self.x_data[subset_indices]
-                    y_subset = self.y_data[subset_indices]
-                    if isinstance(x_subset, torch.Tensor) and x_subset.is_cuda or (torch.backends.mps.is_available() and x_subset.is_mps):
-                        x_subset = x_subset.cpu()
-                    if isinstance(y_subset, torch.Tensor) and y_subset.is_cuda or (torch.backends.mps.is_available() and y_subset.is_mps):
-                        y_subset = y_subset.cpu()
+                    x_subset = _ensure_cpu(self.x_data[subset_indices])
+                    y_subset = _ensure_cpu(self.y_data[subset_indices])
                     task_run_id = f"{run_id_base}_c{i_combo}_g{gamma}_s{i_subset}"
                     tasks.append((x_subset, y_subset, current_params.copy(), task_run_id))
 

--- a/neural_mi/analysis/sweep.py
+++ b/neural_mi/analysis/sweep.py
@@ -15,7 +15,7 @@ from typing import List, Dict, Any, Optional
 
 from neural_mi.analysis.task import run_training_task
 from neural_mi.logger import logger
-from neural_mi.utils import _configure_multiprocessing
+from neural_mi.utils import _configure_multiprocessing, _ensure_cpu
 from neural_mi.defaults import PROCESSOR_PARAMS_SCHEMA
 
 def _product_dict(**kwargs: Dict[str, List]) -> List[Dict[str, Any]]:
@@ -177,18 +177,18 @@ class ParameterSweep:
             })
             
             if is_proc_sweep:
-                task_data_x, task_data_y = self.x_data, self.y_data
+                # Raw data path: processor runs inside the worker, so tensors
+                # must still be on CPU before crossing the process boundary.
+                task_data_x = _ensure_cpu(self.x_data)
+                task_data_y = _ensure_cpu(self.y_data)
             else:
                 x_to_send, y_to_send = self.x_data, self.y_data
                 if max_samples_per_task and self.x_data is not None and self.x_data.shape[0] > max_samples_per_task:
                     indices = np.random.choice(self.x_data.shape[0], max_samples_per_task, replace=False)
                     x_to_send = self.x_data[indices]
                     y_to_send = self.y_data[indices] if self.y_data is not None else None
-                if isinstance(x_to_send, torch.Tensor) and (x_to_send.is_cuda or (hasattr(x_to_send, 'is_mps') and x_to_send.is_mps)):
-                    x_to_send = x_to_send.cpu()
-                if y_to_send is not None and isinstance(y_to_send, torch.Tensor) and (y_to_send.is_cuda or (hasattr(y_to_send, 'is_mps') and y_to_send.is_mps)):
-                    y_to_send = y_to_send.cpu()
-                task_data_x, task_data_y = x_to_send, y_to_send
+                task_data_x = _ensure_cpu(x_to_send)
+                task_data_y = _ensure_cpu(y_to_send)
 
             task_run_id = f"{run_id_base}_c{i_combo}"
             tasks.append((task_data_x, task_data_y, current_params.copy(), task_run_id))

--- a/neural_mi/utils.py
+++ b/neural_mi/utils.py
@@ -17,6 +17,21 @@ from neural_mi.models.embeddings import MLP, VarMLP, BaseEmbedding, CNN1D, GRU, 
 from neural_mi.models.critics import SeparableCritic, ConcatCritic, BaseCritic, HybridCritic
 from neural_mi.logger import logger
 
+def _ensure_cpu(data):
+    """Move *data* to CPU if it is a tensor on a non-CPU device.
+
+    Multiprocessing workers receive data via pickle (spawn context), which
+    requires all tensors to reside on CPU — CUDA and MPS shared-memory
+    mechanisms are not available across process boundaries.  Call this on
+    every tensor before adding it to a Pool task tuple.
+
+    Non-tensor inputs (numpy arrays, None, etc.) are returned unchanged.
+    """
+    if isinstance(data, torch.Tensor) and data.device.type != 'cpu':
+        return data.cpu()
+    return data
+
+
 def get_device(device_str: Optional[str] = None) -> torch.device:
     """Selects the appropriate device, including 'mps' for Apple Silicon."""
     if device_str:


### PR DESCRIPTION
Multiprocessing workers spawned via mp.get_context('spawn') cannot receive tensors on MPS or CUDA devices — PyTorch's shared-memory mechanism for those backends is process-local only, causing:

    RuntimeError: _share_filename_: only available on CPU

Three bugs fixed:

1. dimensionality.py — split_tasks tuples were built with raw tensor slices (x_a, x_b) from the user's input, with no CPU conversion at all. Fixed at all three task-building sites (interaction, temporal, random/spatial).

2. sweep.py — the is_proc_sweep=True branch passed self.x_data / self.y_data directly to workers; only the is_proc_sweep=False branch had the CPU conversion. Unified both paths via _ensure_cpu.

3. rigorous.py — had CPU conversion but with an operator-precedence bug: isinstance(x, Tensor) and x.is_cuda or (mps_avail and x.is_mps) which could AttributeError if x is not a Tensor when MPS is available. Replaced with _ensure_cpu.

Fix: add _ensure_cpu(data) helper to utils.py that checks data.device.type != 'cpu' and calls .cpu() — works uniformly for CUDA, MPS, and any future non-CPU backend. All three files now import and use it.

All 213 tests pass.