### PR TITLE
fix: release device memory after each training task to prevent OOM on…

### DIFF
--- a/neural_mi/analysis/task.py
+++ b/neural_mi/analysis/task.py
@@ -182,5 +182,25 @@ def run_training_task(args: tuple) -> Dict[str, Any]:
     return_params = params.copy()
     return_params.pop('custom_critic', None)
     return_params.pop('custom_embedding_cls', None)
+    final_result = {**return_params, **results}
 
-    return {**return_params, **results}
+    # Explicitly release device-bound objects so the backend allocator can
+    # reclaim their memory.  Without this, PyTorch's MPS/CUDA caches grow
+    # monotonically across sequential tasks and can exhaust system RAM.
+    import gc as _gc
+    del trainer, critic, optimizer, dataset
+    if scheduler is not None:
+        del scheduler
+
+    _device_type = getattr(device, 'type', 'cpu')
+    if _device_type == 'cuda':
+        torch.cuda.synchronize()
+        torch.cuda.empty_cache()
+    elif _device_type == 'mps':
+        if hasattr(torch, 'mps') and hasattr(torch.mps, 'synchronize'):
+            torch.mps.synchronize()
+        if hasattr(torch, 'mps') and hasattr(torch.mps, 'empty_cache'):
+            torch.mps.empty_cache()
+    _gc.collect()
+
+    return final_result


### PR DESCRIPTION
… long sweeps

Explicitly del trainer/critic/optimizer/scheduler/dataset at the end of run_training_task, then call the appropriate backend cache-flush:
- CUDA: torch.cuda.synchronize() + torch.cuda.empty_cache()
- MPS:  torch.mps.synchronize() + torch.mps.empty_cache() (guarded with hasattr for PyTorch < 2.0 compatibility)
- CPU:  gc.collect() only

Without this, PyTorch's MPS/CUDA allocators accumulate freed tensors in an internal cache that is never returned to the OS.  On Apple Silicon (unified DRAM) this causes monotonic memory growth across sequential sweep tasks and can freeze the system.